### PR TITLE
Update to `errors` method. Fix for eating errors.

### DIFF
--- a/lib/src/validators/abstractValidator.dart
+++ b/lib/src/validators/abstractValidator.dart
@@ -56,13 +56,16 @@ abstract class AbstractValidator<T> {
   ///Returns all errors in a text format.  Errors are separated by delimiter (default is a space).
   ///IMPORTANT: Executing this method has the side-effect of also executing validate().
   String errors() {
-    var lst = validate();
+    // Get a list of all the errorText properties.
+    var lst = validate().map((element) => element.errorText);
+    // If all elements of the list are null return null.
+    if (lst.every((element) => element == null)) return null;
+
     String result = lst.fold<String>('', (previous, element) {
-      return element.errorText != null
-          ? '$previous ${element.errorText}'
-          : null;
+      return element != null
+          ? '$previous ${element}'
+          : '$previous';
     });
-    if (result == null) return null;
     return result.trim();
   }
 }


### PR DESCRIPTION
I had an issue where the value returned from `.errors()` was null when some rules passed and others failed. I believe this is because if the last validation rule has no errors then the value of `result` became `null`, thus returning `null` and losing previous `errorText`. With this proposed change it is now working as expected.

Hope this is helpful. If you need additional information please let me know.

```dart
    // title
    validator.ruleFor('title', () => title)
      ..must((value) {
        return value is String;
      })
      ..withMessage('title must be a string.')
      ..length(0, 200)
      ..withMessage('title must be less than 200 characters.');

    // Missing Data
    // assetID
    validator.ruleFor('assetID', () => assetID)
      ..must((value) {
        return value is String;
      })
      ..withMessage('assetID must be a string.')
      ..length(0, 200)
      ..withMessage('assetID must be less than 200 characters.');

    // Missing data
    // closedTasks     
    validator.ruleFor('closedTasks', () => closedTasks)
      ..must((value) {
        return value is List<String> && value.isEmpty;
      })
      ..withMessage('closedTasks must be an empty list on creation.');

    // If this rule passed, it would not show errors for assetID or closedTasks rules.
    // description
    validator.ruleFor('description', () => description)
      ..length(0, 1000)
      ..withMessage('description must be less than 1000 characters');
```