### PR TITLE
Update intl package to ^0.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: any
+  intl: ^0.16.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_validate
 description: A Flutter package for performing validation using a fluent interface approach.
 version: 1.0.1
-author: 'Joe Ebright <ebrightster@gmail.com>'
+author: "Joe Ebright <ebrightster@gmail.com>"
 homepage: https://github.com/jebright/flutter_validate
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.15.7
+  intl: any
 
 dev_dependencies:
   flutter_test:
@@ -21,7 +21,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # To add assets to your package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
@@ -32,7 +31,6 @@ flutter:
   #
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.io/assets-and-images/#resolution-aware.
-
   # To add custom fonts to your package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a


### PR DESCRIPTION
The issue:

```
Running "flutter pub get" in app...     
Because engineer_forum depends on flutter_validate ^1.0.2 which depends on intl ^0.15.7, intl ^0.15.7 is required.
So, because app depends on intl ^0.16.0, version solving failed.
pub get failed (1)
exit code 1
```

The solution:

`Update the intl package to  ^0.16.0`